### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/kschandan113/4c598a08-1b10-4e92-acdd-1dd3e68b02d8/1e59c4e2-66ad-4c6a-ba19-91747292db8a/_apis/work/boardbadge/380d42aa-ad10-4c4c-8dd3-876769fe4441)](https://dev.azure.com/kschandan113/4c598a08-1b10-4e92-acdd-1dd3e68b02d8/_boards/board/t/1e59c4e2-66ad-4c6a-ba19-91747292db8a/Microsoft.RequirementCategory)
 # gitBoards


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#14. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.